### PR TITLE
Lib should not have allowbakup attribute

### DIFF
--- a/liquidButtonLib/src/main/AndroidManifest.xml
+++ b/liquidButtonLib/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.gospelware.liquidbutton">
 
-    <application android:allowBackup="true" android:label="@string/app_name"
+    <application android:label="@string/app_name"
         android:supportsRtl="true">
 
     </application>


### PR DESCRIPTION
**Remove android:allowBackup="true"** from AndroidManifest file as it is giving Manifest merger issues with the application manifest file and the other libraries Manifest file. It's not necessary for your lib.
Error seems like: "Manifest merger failed : Attribute application@allowBackup value=(false)".

Thank you very much for the great lib.